### PR TITLE
fix: Linux環境でコンパイルエラーになるので修正

### DIFF
--- a/src/preload/chatbox.ts
+++ b/src/preload/chatbox.ts
@@ -1,5 +1,5 @@
-import attachChatBox from "./chat/attachChatBox";
-import sendDebugLog from "./debug/sendDebugLog";
+import attachChatBox from "./Chat/attachChatBox";
+import sendDebugLog from "./Debug/sendDebugLog";
 import { AppendSuperchat } from "@common/AppState/Actions/AppStateAction";
 import { SuperChatInfo } from "@common/AppState/AppState";
 import createSharedStore from "@common/Middlewares/WebcontentsPreloadMiddleware";


### PR DESCRIPTION
Linux環境で `yarn dev` を実行したところ、以下のコンパイルエラーが発生したので修正しました。

```
$ uname -a
Linux blacky-UX390UAK 5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ yarn dev
...(省略)
    ERROR in /home/blacky/projects/nodejs/YoutubeLiveApp/src/preload/chatbox.ts
    [tsl] ERROR in /home/blacky/projects/nodejs/YoutubeLiveApp/src/preload/chatbox.ts(1,27)
          TS2307: Cannot find module './chat/attachChatBox' or its corresponding type declarations.

    ERROR in /home/blacky/projects/nodejs/YoutubeLiveApp/src/preload/chatbox.ts
    [tsl] ERROR in /home/blacky/projects/nodejs/YoutubeLiveApp/src/preload/chatbox.ts(2,26)
          TS2307: Cannot find module './debug/sendDebugLog' or its corresponding type declarations.
```

おそらく、Linuxのファイルシステム(ext4など)ではファイル名の参照がcase-sensitiveなのが原因だと思います。